### PR TITLE
Updates URL regex again

### DIFF
--- a/js/sketchfab.js
+++ b/js/sketchfab.js
@@ -112,8 +112,9 @@ var SketchfabPlugin = function SketchfabPlugin(opt) {
 };
 
 SketchfabPlugin.prototype.getModelUID = function(url) {
-    // Remove query string, hash, path, and slug
-    return url.split(/[?#]/).shift().split('-').slice(-1).shift();
+    var urlRegex = /https:\/\/sketchfab\.com\/(3d-)?models\/([\w-]+)/;
+    var uid = url.match(urlRegex)[2].split('-').splice(-1).shift();
+    return uid;
 };
 
 SketchfabPlugin.prototype.open = function open(e) {


### PR DESCRIPTION
This is to backport https://github.com/sketchfab/vanilla-plugin/pull/9 into Vanilla's fork of the Sketchfab-vanilla plugin. 